### PR TITLE
Add Changelog to release 4.5.0

### DIFF
--- a/net.sonic_pi.SonicPi.appdata.xml
+++ b/net.sonic_pi.SonicPi.appdata.xml
@@ -1,47 +1,83 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2020 Sonic-Pi Developers -->
 <component type="desktop">
- <id>net.sonic_pi.SonicPi</id>
- <metadata_license>CC0</metadata_license>
- <project_license>MIT and CC-BY-SA-4.0+</project_license>
- <name>Sonic Pi</name>
- <summary>A code-based music creation and performance tool</summary>
- <description>
-   <p>
-     Sonic Pi is a code-based music creation and performance tool.
-   </p>
-   <ul>
-     <li>Simple enough for computing and music lessons.</li>
-     <li>Powerful enough for professional musicians.</li>
-     <li>Free to download with a friendly tutorial.</li>
-     <li>Diverse community of over 1.8 million live coders.</li>
-   </ul>
-   <p>
-     Learn to code creatively by composing or performing music in an
-     incredible range of styles from Classical &amp; Jazz to Grime
-     &amp; EDM.
-   </p>
- </description>
- <content_rating type="oars-1.1" />
- <launchable type="desktop-id">net.sonic_pi.SonicPi.desktop</launchable>
- <translation type="qt">sonic-pi</translation>
- <screenshots>
-  <screenshot type="default">
-   <image>https://sonic-pi.net/media/images/tutorial/GUI.png</image>
-   <caption>The SonicPi UI (tutorial version)</caption>
-  </screenshot>
- </screenshots>
- <update_contact>hub_AT_figuiere.net</update_contact>
- <url type="homepage">https://sonic-pi.net/</url>
- <url type="bugtracker">https://github.com/sonic-pi-net/sonic-pi/issues</url>
- <url type="help">https://sonic-pi.net/tutorial.html</url>
- <releases>
-   <release version="4.5.0" date="2023-10-21" />
-   <release version="4.4.0" date="2023-06-30" />
-   <release version="4.3.0" date="2022-09-30" />
-   <release version="4.2.0" date="2022-09-14" />
-   <release version="3.3.1" date="2021-02-01" />
-   <release version="3.3.0" date="2021-01-28" />
-   <release version="3.2.2" date="2020-04-06" />
- </releases>
+    <id>net.sonic_pi.SonicPi</id>
+    <metadata_license>CC0</metadata_license>
+    <project_license>MIT and CC-BY-SA-4.0+</project_license>
+    <name>Sonic Pi</name>
+    <summary>A code-based music creation and performance tool</summary>
+    <description>
+        <p>
+            Sonic Pi is a code-based music creation and performance tool.
+        </p>
+        <ul>
+            <li>Simple enough for computing and music lessons.</li>
+            <li>Powerful enough for professional musicians.</li>
+            <li>Free to download with a friendly tutorial.</li>
+            <li>Diverse community of over 1.8 million live coders.</li>
+        </ul>
+        <p>
+            Learn to code creatively by composing or performing music in an
+            incredible range of styles from Classical &amp; Jazz to Grime
+            &amp; EDM.
+        </p>
+    </description>
+    <content_rating type="oars-1.1" />
+    <launchable type="desktop-id">net.sonic_pi.SonicPi.desktop</launchable>
+    <translation type="qt">sonic-pi</translation>
+    <screenshots>
+        <screenshot type="default">
+            <image>https://sonic-pi.net/media/images/tutorial/GUI.png</image>
+            <caption>The SonicPi UI (tutorial version)</caption>
+        </screenshot>
+    </screenshots>
+    <update_contact>hub_AT_figuiere.net</update_contact>
+    <url type="homepage">https://sonic-pi.net/</url>
+    <url type="bugtracker">https://github.com/sonic-pi-net/sonic-pi/issues</url>
+    <url type="help">https://sonic-pi.net/tutorial.html</url>
+    <releases>
+        <release version="4.5.0" date="2023-11-01">
+            <description>
+                <p>This release comes packed with a number of exciting new synths for you to play with. We have a new hard-hitting kick drum <code>:gabberkick</code> for that gabber sound and a new vintage electric piano <code>:rhodey</code> synth. There are also 16 new percussive synths inspired by the infamous TR-808 drum synthesiser. All the synths come with many opts for you to play with to manipulate and change the default timbres.</p>
+
+                <p>There are also a number of minor improvements and bug fixes as detailed below.</p>
+
+                <p>Have fun and get your live coded 808 on!</p>
+
+                <p>Synths:</p>
+
+                <ul>
+                    <li>New synth: <code>:rhodey</code> - The sound of an electric piano from the 60&#8217;s and 70&#8217;s, producing a characteristic metallic sound for notes below <code>:g2</code>. Adapted for Sonic Pi from <a href="https://sccode.org/1-522">SuperCollider Code</a>.</li>
+                    <li>New synth <code>:gabberkick</code> - An aggressive Gabber synth sound adapted for Sonic Pi from <a href="https://sccode.org/1-57r">SuperCollider Code</a></li>
+                    <li>16 new 808 inspired synths based on <a href="https://www.patreon.com/4H/posts">Yoshinosuke Horiuchi&#8217;s</a>: <code>:sc808_bassdrum</code>, <code>:sc808_snare</code>, <code>:sc808_clap</code>, <code>:sc808_tomlo</code>, <code>:sc808_tommid</code>, <code>:sc808_tomhi</code>, <code>:sc808_congalo</code>, <code>:sc808_congamid</code>, <code>:sc808_congahi</code>, <code>:sc808_rimshot</code>, <code>:sc808_claves</code>, <code>:sc808_maracas</code>, <code>:sc808_cowbell</code>, <code>:sc808_closed_hihat</code>, <code>:sc808_open_hihat</code>, <code>:sc808_cymbal</code>,</li>
+                </ul>
+
+                <p>Improvements:</p>
+
+                <ul>
+                    <li>Improve error message for invalid <code>midi_to_hz</code> args</li>
+                </ul>
+
+                <p>Translations:</p>
+
+                <ul>
+                    <li>Improvements to the Chinese, Danish, Portuguese, and Spanish translations.</li>
+                    <li>Add native language name for Arabic</li>
+                </ul>
+
+                <p>Bugfixes:</p>
+
+                <ul>
+                    <li>Fixed a regression in the error reporting - &#8220;did you mean&#8221; suggestions now work again.</li>
+                    <li>Fix system language detection when the language is generic English</li>
+                </ul>
+            </description>
+        </release>
+        <release version="4.4.0" date="2023-06-30" />
+        <release version="4.3.0" date="2022-09-30" />
+        <release version="4.2.0" date="2022-09-14" />
+        <release version="3.3.1" date="2021-02-01" />
+        <release version="3.3.0" date="2021-01-28" />
+        <release version="3.2.2" date="2020-04-06" />
+    </releases>
 </component>


### PR DESCRIPTION
We were not adding any changelog to any release, which looks kind of sad on flathub.org:

![Screenshot 2023-11-02 at 22-19-01 Sonic Pi Flathub](https://github.com/flathub/net.sonic_pi.SonicPi/assets/3830/e4691f71-b03e-49ca-a155-c0534751805b)

I simply copied it from the project changelog.md (converting markdown to HTML).

Also fixed the release date, and the indentation of the whole file (so a big chunk of the diff is just whitespace).

My question is: is it ok flatpak practice to update this file without it being a new release? In that case we leave this for next release, but it would be nice to have it.