### PR TITLE
Flatpak: Add org.jackaudio.service talk-name permission

### DIFF
--- a/net.sonic_pi.SonicPi.json
+++ b/net.sonic_pi.SonicPi.json
@@ -14,6 +14,7 @@
         "--device=dri",
         "--share=network",
         "--filesystem=xdg-run/pipewire-0",
+        "--talk-name=org.jackaudio.service",
         "--talk-name=org.mpris.MediaPlayer2",
         "--filesystem=home",
         "--env=TMPDIR=/var/tmp",


### PR DESCRIPTION
This allows the sandboxed SuperCollider engine to register as a JACK client with PipeWire, fixing the 'no sound but scope works' issue by enabling automatic audio output routing.